### PR TITLE
Change speed(,,,) method to set_speed(...)

### DIFF
--- a/library/flotilla/motor.py
+++ b/library/flotilla/motor.py
@@ -15,6 +15,6 @@ class Motor(Module):
         self.speed = 0
         self.update()
 
-    def speed(self, speed):
+    def set_speed(self, speed):
         self.speed = self.clamp(speed, -63, 63)
         self.update()


### PR DESCRIPTION
The speed() method name conflicted with the speed attribute name.
This caused an exception when calling it.
set_speed(...) is also more consistent with the naming of the setter
methods in the other Flotilla module classes.
